### PR TITLE
드로잉 반영

### DIFF
--- a/DrawingAppGucci/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingAppGucci/DrawingApp.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0000216B28AA0E6000CC21ED /* UIFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0000216A28AA0E6000CC21ED /* UIFactory.swift */; };
+		0005759B28B494A500600402 /* CanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0005759A28B494A500600402 /* CanvasView.swift */; };
 		001B7D6228A0D82100BEF034 /* Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B7D6128A0D82100BEF034 /* Text.swift */; };
 		001B7D6428A0E4C700BEF034 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 001B7D6328A0E4C700BEF034 /* TextView.swift */; };
 		003E1D96288B1A0E0077783E /* Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003E1D95288B1A0E0077783E /* Size.swift */; };
@@ -68,6 +69,7 @@
 
 /* Begin PBXFileReference section */
 		0000216A28AA0E6000CC21ED /* UIFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFactory.swift; sourceTree = "<group>"; };
+		0005759A28B494A500600402 /* CanvasView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasView.swift; sourceTree = "<group>"; };
 		001B7D6128A0D82100BEF034 /* Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Text.swift; sourceTree = "<group>"; };
 		001B7D6328A0E4C700BEF034 /* TextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextView.swift; sourceTree = "<group>"; };
 		003E1D95288B1A0E0077783E /* Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Size.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 				00A9D5D8287BFC68002A6049 /* SquareView.swift */,
 				00CC7C80288E47E3009E0D0A /* PhotoView.swift */,
 				001B7D6328A0E4C700BEF034 /* TextView.swift */,
+				0005759A28B494A500600402 /* CanvasView.swift */,
 				00DA93B928A50393000DBC48 /* LayerTableViewCell.swift */,
 				0000216A28AA0E6000CC21ED /* UIFactory.swift */,
 				0057428728743F9500080F14 /* Main.storyboard */,
@@ -428,6 +431,7 @@
 				003E1D9A288B1A170077783E /* Color.swift in Sources */,
 				004C649028AB770A00C63D86 /* ViewControllExtension.swift in Sources */,
 				004C649228AB774900C63D86 /* TableCellDragAndDrop.swift in Sources */,
+				0005759B28B494A500600402 /* CanvasView.swift in Sources */,
 				00DE6F0C28784B7600738FC8 /* Extension +.swift in Sources */,
 				001B7D6228A0D82100BEF034 /* Text.swift in Sources */,
 				00CC7C7F288E3F8E009E0D0A /* Photo.swift in Sources */,

--- a/DrawingAppGucci/DrawingApp.xcodeproj/project.pbxproj
+++ b/DrawingAppGucci/DrawingApp.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		005742B428744AA400080F14 /* Alpha.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005742B328744AA400080F14 /* Alpha.swift */; };
 		005742B628744CAC00080F14 /* ShapeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 005742B528744CAC00080F14 /* ShapeFactory.swift */; };
 		007A77F528AC5CAE0018F3C9 /* Direction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007A77F428AC5CAE0018F3C9 /* Direction.swift */; };
+		0091A5E628B59B4F005C6DC9 /* LineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0091A5E528B59B4F005C6DC9 /* LineView.swift */; };
+		0091A5E828B5A550005C6DC9 /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0091A5E728B5A550005C6DC9 /* Line.swift */; };
 		00A9D5D9287BFC68002A6049 /* SquareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A9D5D8287BFC68002A6049 /* SquareView.swift */; };
 		00CA7E8A2890DBEA008974EF /* ShapeBlueprint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CA7E892890DBEA008974EF /* ShapeBlueprint.swift */; };
 		00CA7E8C2890FA78008974EF /* Shape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CA7E8B2890FA78008974EF /* Shape.swift */; };
@@ -100,6 +102,8 @@
 		005742B328744AA400080F14 /* Alpha.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alpha.swift; sourceTree = "<group>"; };
 		005742B528744CAC00080F14 /* ShapeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeFactory.swift; sourceTree = "<group>"; };
 		007A77F428AC5CAE0018F3C9 /* Direction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Direction.swift; sourceTree = "<group>"; };
+		0091A5E528B59B4F005C6DC9 /* LineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
+		0091A5E728B5A550005C6DC9 /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
 		00A9D5D8287BFC68002A6049 /* SquareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquareView.swift; sourceTree = "<group>"; };
 		00CA7E892890DBEA008974EF /* ShapeBlueprint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeBlueprint.swift; sourceTree = "<group>"; };
 		00CA7E8B2890FA78008974EF /* Shape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shape.swift; sourceTree = "<group>"; };
@@ -196,6 +200,7 @@
 				00DE6F0D28784BD100738FC8 /* Plane.swift */,
 				005742B528744CAC00080F14 /* ShapeFactory.swift */,
 				001B7D6128A0D82100BEF034 /* Text.swift */,
+				0091A5E728B5A550005C6DC9 /* Line.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -208,6 +213,7 @@
 				00A9D5D8287BFC68002A6049 /* SquareView.swift */,
 				00CC7C80288E47E3009E0D0A /* PhotoView.swift */,
 				001B7D6328A0E4C700BEF034 /* TextView.swift */,
+				0091A5E528B59B4F005C6DC9 /* LineView.swift */,
 				0005759A28B494A500600402 /* CanvasView.swift */,
 				00DA93B928A50393000DBC48 /* LayerTableViewCell.swift */,
 				0000216A28AA0E6000CC21ED /* UIFactory.swift */,
@@ -422,6 +428,7 @@
 				005742B628744CAC00080F14 /* ShapeFactory.swift in Sources */,
 				00CC7C7D288E2577009E0D0A /* Notification +.swift in Sources */,
 				00CA7E8C2890FA78008974EF /* Shape.swift in Sources */,
+				0091A5E628B59B4F005C6DC9 /* LineView.swift in Sources */,
 				003E1D9C288B1A1C0077783E /* Bound.swift in Sources */,
 				0000216B28AA0E6000CC21ED /* UIFactory.swift in Sources */,
 				00DA93BA28A50393000DBC48 /* LayerTableViewCell.swift in Sources */,
@@ -447,6 +454,7 @@
 				004C648A28AB760A00C63D86 /* VCNotificationExtension.swift in Sources */,
 				00CC7C81288E47E3009E0D0A /* PhotoView.swift in Sources */,
 				004C648828AB757E00C63D86 /* PHPickerDeleagte.swift in Sources */,
+				0091A5E828B5A550005C6DC9 /* Line.swift in Sources */,
 				004C648628AB71A900C63D86 /* VCShapeExtension.swift in Sources */,
 				004C648E28AB76CF00C63D86 /* TableViewDataSource.swift in Sources */,
 			);

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Entry/Point.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Entry/Point.swift
@@ -7,7 +7,8 @@
 
 import Foundation
 
-struct Point {
+struct Point: Codable {
+    
     var x: Double
     var y: Double
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Entry/ShapeBlueprint.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Entry/ShapeBlueprint.swift
@@ -12,4 +12,5 @@ enum ShapeBlueprint: String {
     case rectangle
     case photo
     case text
+    case drawing
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Entry/ShapeBlueprint.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Entry/ShapeBlueprint.swift
@@ -9,8 +9,8 @@ import Foundation
 
 // MARK: - FactoryMethod 패턴으로 작업할 때, make 메서드에서 어떤 것을 사용하면 더 수월하게 변환 할 수 있을지 알려주는 열거형
 enum ShapeBlueprint: String {
-    case rectangle
-    case photo
-    case text
-    case drawing
+    case rectangle = "Rect"
+    case photo = "Photo"
+    case text = "Text"
+    case drawing = "Drawing"
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Line.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Line.swift
@@ -9,6 +9,7 @@ import Foundation
 
 final class Line: Shape {
     private(set) var lines: [[Point]]
+    private(set) var color: Color = Color(r: 0, g: 0, b: 0)
     
     init(shape: Shape, lines: [[Point]]) {
         self.lines = lines
@@ -24,5 +25,9 @@ final class Line: Shape {
     override func encode(with coder: NSCoder) {
         super.encode(with: coder)
         coder.encode(lines, forKey: "lines")
+    }
+    
+    func setRandomColor() {
+        self.color = Color()
     }
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Line.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Line.swift
@@ -1,0 +1,28 @@
+//
+//  Line.swift
+//  DrawingApp
+//
+//  Created by YEONGJIN JANG on 2022/08/24.
+//
+
+import Foundation
+
+final class Line: Shape {
+    private(set) var lines: [[Point]]
+    
+    init(shape: Shape, lines: [[Point]]) {
+        self.lines = lines
+        super.init(id: shape.id, size: shape.size, point: shape.point, alpha: shape.alpha, bound: shape.bound)
+    }
+    
+    required init?(coder: NSCoder) {
+        guard let lines = coder.decodeObject(forKey: "lines") as? [[Point]] else { assert(false) }
+        self.lines = lines
+        super.init(coder: coder)
+    }
+    
+    override func encode(with coder: NSCoder) {
+        super.encode(with: coder)
+        coder.encode(lines, forKey: "lines")
+    }
+}

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Plane.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Plane.swift
@@ -95,6 +95,7 @@ final class Plane: NSObject, Planable {
             alpha = text.alpha
         case let drawing as Line:
             drawing.setRandomColor()
+            color = drawing.color
             blueprint = .drawing
             alpha = .ten
         default:

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Plane.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Plane.swift
@@ -93,6 +93,10 @@ final class Plane: NSObject, Planable {
             text.changeAlpha(value: alphaValue ?? 0)
             blueprint = .text
             alpha = text.alpha
+        case let drawing as Line:
+            drawing.setRandomColor()
+            blueprint = .drawing
+            alpha = .ten
         default:
             assert(false, "failure at type casting")
         }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Plane.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Plane.swift
@@ -40,7 +40,7 @@ final class Plane: NSObject, Planable {
     }
     
     //MARK: - 도형 추가
-    func makeShape(with blueprint: ShapeBlueprint, by urlData: Data? = nil) { 
+    func makeShape(with blueprint: ShapeBlueprint, by urlData: Data? = nil) {
         let shape = factory.generateShape(with: blueprint, urlData: urlData)
         shapes.append(shape)
         

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/ShapeFactory.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/ShapeFactory.swift
@@ -59,8 +59,16 @@ final class ShapeFactory {
             let textSize = Size(width: Double(string.count) * 13, height: 35)
             shape.size = textSize
             return Text(shape: shape, string: string)
+        case .drawing:
+            guard let linesData = urlData,
+                  let lines = try? JSONDecoder().decode([[Point]].self, from: linesData)
+            else { assert(false) }
+            let pointAndSize = makeOriginPointAndSize(from: lines)
+            shape.point = pointAndSize.point
+            shape.size = pointAndSize.size
+            
+            return Line(shape: shape, lines: lines)
         }
-        
     }
     
      private func generateUUID() -> String {
@@ -125,4 +133,34 @@ final class ShapeFactory {
         result.removeLast()
         return result
     }
+    
+        private func makeOriginPointAndSize(from lines: [[Point]]) -> (point: Point, size: Size) {
+            //x, y 중에 가장 0에 가까운 것을 찾아서 Point 로 만들기
+            var minX: Double = Double(Int.max)
+            var minY: Double = Double(Int.max)
+            var maxX: Double = 0.0
+            var maxY: Double = 0.0
+            lines.forEach { line in
+                //TODO: - switch (point.x, point.y) {} 로 할 필요 없는지 확인
+                line.forEach { point in
+                    if point.x < minX {
+                        minX = point.x
+                    }
+                    if point.y < minY {
+                        minY = point.y
+                    }
+                    if point.x > maxX {
+                        maxX = point.x
+                    }
+                    if point.y > maxY {
+                        maxY = point.y
+                    }
+                }
+                
+            }
+            return (
+                Point.init(x: minX, y: minY),
+                Size(width: maxX - minX, height: maxY - minY)
+            )
+        }
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/ShapeFactory.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/ShapeFactory.swift
@@ -66,7 +66,7 @@ final class ShapeFactory {
             let pointAndSize = makeOriginPointAndSize(from: lines)
             shape.point = pointAndSize.point
             shape.size = pointAndSize.size
-            
+//            shape.changeAlpha(value: 1)
             return Line(shape: shape, lines: lines)
         }
     }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/ShapeFactory.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/ShapeFactory.swift
@@ -66,7 +66,7 @@ final class ShapeFactory {
             let pointAndSize = makeOriginPointAndSize(from: lines)
             shape.point = pointAndSize.point
             shape.size = pointAndSize.size
-//            shape.changeAlpha(value: 1)
+            shape.changeAlpha(value: 1)
             return Line(shape: shape, lines: lines)
         }
     }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Text.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/Model/Text.swift
@@ -17,7 +17,8 @@ final class Text: Shape {
     }
     
     required init?(coder: NSCoder) {
-        string = coder.decodeObject(forKey: "string") as! String
+        guard let string = coder.decodeObject(forKey: "string") as? String else { assert(false) }
+        self.string = string
         super.init(coder: coder)
     }
     

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/Base.lproj/Main.storyboard
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/Base.lproj/Main.storyboard
@@ -320,7 +320,7 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="SfJ-tN-geC">
-                                <rect key="frame" x="385.5" y="650" width="409" height="100"/>
+                                <rect key="frame" x="334" y="650" width="512" height="100"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="46x-0U-M0D">
                                         <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
@@ -376,6 +376,20 @@
                                         <buttonConfiguration key="configuration" style="gray" title="텍스트"/>
                                         <connections>
                                             <action selector="touchedTextButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xzH-mo-U1i"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fRT-Kc-Rsv">
+                                        <rect key="frame" x="412" y="0.0" width="100" height="100"/>
+                                        <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="SVU-h5-1og"/>
+                                            <constraint firstAttribute="height" constant="100" id="ct3-lL-BHf"/>
+                                        </constraints>
+                                        <color key="tintColor" systemColor="labelColor"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="드로잉"/>
+                                        <connections>
+                                            <action selector="touchedDrawingButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CHV-xS-akK"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/Base.lproj/Main.storyboard
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/Base.lproj/Main.storyboard
@@ -396,8 +396,9 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aTK-gC-RH4">
+                            <view clearsContextBeforeDrawing="NO" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aTK-gC-RH4" customClass="CanvasView" customModule="DrawingApp" customModuleProvider="target">
                                 <rect key="frame" x="241" y="24" width="698" height="621"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <gestureRecognizers/>
                                 <connections>
                                     <outletCollection property="gestureRecognizers" destination="KF2-Ix-xug" appends="YES" id="sOX-ge-rYj"/>

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
@@ -10,18 +10,12 @@ import UIKit
 final class CanvasView: UIView {
 
     private var lines = [[CGPoint]]()
-    private var path: CGPath?
-    
-    override func draw(_ rect: CGRect) {
-        super.draw(rect)
-//        guard let context = UIGraphicsGetCurrentContext() else { return }
-//
-//        UIGraphicsPushContext(context)
-
-    }
+    private var isCanDrawing: Bool = false
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        lines.append([CGPoint]())
+        if isCanDrawing {
+            lines.append([CGPoint]())
+        }
     }
     
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -40,8 +34,13 @@ final class CanvasView: UIView {
     }
     
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        postNotification(with: lines)
+        guard let firstLine = lines.first else { return }
+        
+        if isCanDrawing && !firstLine.isEmpty {
+            postNotification(with: lines)
+        }
         self.lines = []
+//        self.isCanDrawing.toggle()
     }
 }
 
@@ -53,5 +52,9 @@ extension CanvasView {
                 object: self,
                 userInfo: [NotificationKey.shapeObject: lines]
             )
+    }
+    
+    func enableDrawing() {
+        self.isCanDrawing.toggle()
     }
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
@@ -40,7 +40,6 @@ final class CanvasView: UIView {
             postNotification(with: lines)
         }
         self.lines = []
-//        self.isCanDrawing.toggle()
     }
 }
 

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class CanvasView: UIView {
 
-    var lines = [[CGPoint]]()
+    private var lines = [[CGPoint]]()
     
     override func draw(_ rect: CGRect) {
         super.draw(rect)
@@ -24,12 +24,22 @@ final class CanvasView: UIView {
                 }
             }
         }
-        
+          
+//        for (i, p) in points.enumerated() {
+//            if i == 0 {
+//                context.move(to: p)
+//            } else {
+//                context.addLine(to: p)
+//            }
+//        }
+          
         context.setStrokeColor(UIColor.red.cgColor)
-        context.setLineWidth(10)
+        context.setLineWidth(5)
         context.setLineCap(.round)
-        
         context.strokePath()
+//        context.
+        
+        setNeedsDisplay()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -38,7 +48,7 @@ final class CanvasView: UIView {
     
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesMoved(touches, with: event)
-        
+        //MARK: - touches in CanvasView, not nil
         guard let point = touches.first?.location(in: self),
               var line = lines.popLast()
         else { return }
@@ -46,5 +56,25 @@ final class CanvasView: UIView {
         line.append(point)
         lines.append(line)
         setNeedsDisplay()
+    }
+    
+    override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.lines = []
+    }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        postNotification(with: lines)
+        self.lines = []
+    }
+}
+
+extension CanvasView {
+    private func postNotification(with lines: [[CGPoint]]) {
+        NotificationCenter.default
+            .post(
+                name: .add,
+                object: self,
+                userInfo: [NotificationKey.shapeObject: lines]
+            )
     }
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
@@ -14,27 +14,10 @@ final class CanvasView: UIView {
     
     override func draw(_ rect: CGRect) {
         super.draw(rect)
-        guard let context = UIGraphicsGetCurrentContext() else { return }
-        
-        lines.forEach { line in
-            for (i, p) in line.enumerated() {
-                if i == 0 {
-                    context.move(to: p)
-                } else {
-                    context.addLine(to: p)
-                }
-            }
-        }
-          
-        context.setStrokeColor(UIColor.red.cgColor)
-        context.setLineWidth(5)
-        context.setLineCap(.round)
-//        context.strokePath()
-        
-        UIGraphicsPushContext(context)
-        context.saveGState()
-        
-        setNeedsDisplay()
+//        guard let context = UIGraphicsGetCurrentContext() else { return }
+//
+//        UIGraphicsPushContext(context)
+
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -50,7 +33,6 @@ final class CanvasView: UIView {
         
         line.append(point)
         lines.append(line)
-        setNeedsDisplay()
     }
     
     override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
@@ -10,6 +10,7 @@ import UIKit
 final class CanvasView: UIView {
 
     private var lines = [[CGPoint]]()
+    private var path: CGPath?
     
     override func draw(_ rect: CGRect) {
         super.draw(rect)
@@ -25,19 +26,13 @@ final class CanvasView: UIView {
             }
         }
           
-//        for (i, p) in points.enumerated() {
-//            if i == 0 {
-//                context.move(to: p)
-//            } else {
-//                context.addLine(to: p)
-//            }
-//        }
-          
         context.setStrokeColor(UIColor.red.cgColor)
         context.setLineWidth(5)
         context.setLineCap(.round)
-        context.strokePath()
-//        context.
+//        context.strokePath()
+        
+        UIGraphicsPushContext(context)
+        context.saveGState()
         
         setNeedsDisplay()
     }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasView.swift
@@ -1,0 +1,50 @@
+//
+//  CanvasView.swift
+//  DrawingApp
+//
+//  Created by YEONGJIN JANG on 2022/08/23.
+//
+
+import UIKit
+
+final class CanvasView: UIView {
+
+    var lines = [[CGPoint]]()
+    
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+        
+        lines.forEach { line in
+            for (i, p) in line.enumerated() {
+                if i == 0 {
+                    context.move(to: p)
+                } else {
+                    context.addLine(to: p)
+                }
+            }
+        }
+        
+        context.setStrokeColor(UIColor.red.cgColor)
+        context.setLineWidth(10)
+        context.setLineCap(.round)
+        
+        context.strokePath()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        lines.append([CGPoint]())
+    }
+    
+    override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesMoved(touches, with: event)
+        
+        guard let point = touches.first?.location(in: self),
+              var line = lines.popLast()
+        else { return }
+        
+        line.append(point)
+        lines.append(line)
+        setNeedsDisplay()
+    }
+}

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
@@ -175,17 +175,6 @@ final class CanvasViewController: UIViewController {
         beforeSelectedView = shapeFrameViews[index]
         
         //MARK: - 상태창에 알림
-//        if let rectangle = selectedShape as? Rectangle {
-//            self.informSelectedViewToStatus(
-//                color: rectangle.color,
-//                alpha: selectedShape.alpha,
-//                type: .rectangle)
-//        } else {
-//            self.informSelectedViewToStatus(
-//                color: Color(),
-//                alpha: selectedShape.alpha,
-//                type: .photo)
-//        }
         var color: Color = Color()
         var alpha: Alpha = .ten
         var type: ShapeBlueprint = .rectangle

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
@@ -29,7 +29,7 @@ final class CanvasViewController: UIViewController {
     @IBOutlet weak var widthLabel: UILabel!
     @IBOutlet weak var heightLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
-    @IBOutlet weak var backgroundView: UIView!
+    @IBOutlet weak var backgroundView: CanvasView!
     var shapeFrameViews: [UIView] = []
     
     var plane: Plane?

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
@@ -175,17 +175,42 @@ final class CanvasViewController: UIViewController {
         beforeSelectedView = shapeFrameViews[index]
         
         //MARK: - 상태창에 알림
-        if let rectangle = selectedShape as? Rectangle {
-            self.informSelectedViewToStatus(
-                color: rectangle.color,
-                alpha: selectedShape.alpha,
-                type: .rectangle)
-        } else {
-            self.informSelectedViewToStatus(
-                color: Color(),
-                alpha: selectedShape.alpha,
-                type: .photo)
+//        if let rectangle = selectedShape as? Rectangle {
+//            self.informSelectedViewToStatus(
+//                color: rectangle.color,
+//                alpha: selectedShape.alpha,
+//                type: .rectangle)
+//        } else {
+//            self.informSelectedViewToStatus(
+//                color: Color(),
+//                alpha: selectedShape.alpha,
+//                type: .photo)
+//        }
+        var color: Color = Color()
+        var alpha: Alpha = .ten
+        var type: ShapeBlueprint = .rectangle
+        switch selectedShape {
+        case let rectangle as Rectangle:
+            color = rectangle.color
+            alpha = rectangle.alpha
+            type = .rectangle
+        case let photo as Photo:
+            color = Color()
+            alpha = photo.alpha
+            type = .photo
+        case let text as Text:
+            color = Color()
+            alpha = text.alpha
+            type = .text
+        case let line as Line:
+            color = line.color
+            alpha = line.alpha
+            type = .drawing
+        default:
+            assert(false, "형변환에 실패했습니다")
         }
+        
+        informSelectedViewToStatus(color: color, alpha: alpha, type: type)
     }
     
     //MARK: - 사각형 버튼 누르면 실행 되는 액션

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
@@ -150,10 +150,10 @@ final class CanvasViewController: UIViewController {
     
     //MARK: - 슬라이더에 점을 움직이면 실행 되는 액션
     @IBAction func movedDot(_ sender: UISlider) {
-        guard let currentView = beforeSelectedView as? Drawable,
+        guard let currentSquare = beforeSelectedView as? Drawable,
               let plane = plane
         else { return }
-        plane.changeColorAndAlpha(at: currentView.index, by: Double(sender.value))
+        plane.changeColorAndAlpha(at: currentSquare.index, by: Double(sender.value))
     }
     
     //MARK: - 메인 화면에 한 점을 터치하면 실행되는 액션

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/CanvasViewController.swift
@@ -72,6 +72,9 @@ final class CanvasViewController: UIViewController {
         plane.makeShape(with: .text)
     }
     
+    @IBAction func touchedDrawingButton(_ sender: UIButton) {
+        backgroundView.enableDrawing()
+    }
     @IBAction func touchedXUp(_ sender: UIButton) {
         guard let currentView = beforeSelectedView as? Drawable,
               let plane = plane

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/LayerTableViewCell.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/LayerTableViewCell.swift
@@ -60,6 +60,8 @@ final class LayerTableViewCell: UITableViewCell {
             shapeImageView?.image = UIImage(systemName: "photo")
         case .text:
             shapeImageView?.image = UIImage(systemName: "t.square")
+        case .drawing:
+            shapeImageView?.image = UIImage(systemName: "scribble")
         }
     }
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
@@ -1,0 +1,68 @@
+//
+//  DrawingView.swift
+//  DrawingApp
+//
+//  Created by YEONGJIN JANG on 2022/08/24.
+//
+
+import UIKit
+
+final class LineView: UIImageView, Drawable {
+    
+    
+    var index: Int
+    let lines: [[CGPoint]]
+    
+    init(line: Line, index: Int) {
+        self.index = index
+        self.lines = line.lines.map({ line in
+            var tempLine: [CGPoint] = []
+            line.forEach {
+                tempLine.append(CGPoint(x: $0.x, y: $0.y))
+            }
+            return tempLine
+        })
+        super.init(frame: CGRect(x: line.point.x, y: line.point.y, width: line.size.width, height: line.size.height))
+        super.backgroundColor = .green
+        super.layer.opacity = 0.5
+        dump(line.bound)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("This class shoud be made by init(), Not init?(coder:)")
+    }
+    
+//    override func draw(_ rect: CGRect) {
+//        super.draw(rect)
+//        guard let context = UIGraphicsGetCurrentContext() else { return }
+//        
+//        lines.forEach { line in
+//            for (i, p) in line.enumerated() {
+//                if i == 0 {
+//                    context.move(to: p)
+//                } else {
+//                    context.addLine(to: p)
+//                }
+//            }
+//        }
+//          
+////        for (i, p) in points.enumerated() {
+////            if i == 0 {
+////                context.move(to: p)
+////            } else {
+////                context.addLine(to: p)
+////            }
+////        }
+//          
+//        context.setStrokeColor(UIColor.red.cgColor)
+//        context.setLineWidth(5)
+//        context.setLineCap(.round)
+//        context.strokePath()
+//        
+//        setNeedsDisplay()
+//    }
+    
+    func updateAlphaOrColor(alpha: Alpha, color: Color?) {
+        assert(false)
+    }
+}

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
@@ -37,10 +37,10 @@ final class LineView: UIView, Drawable {
     
     override func draw(_ rect: CGRect) {
         super.draw(rect)
-
+        
         let aPath = UIBezierPath()
         let origin = getOrigin(lines: self.lines)
-
+        
         lines.forEach { line in
             for (i, p) in line.enumerated() {
                 let calculatedPoint = CGPoint(x: p.x - origin.x, y: p.y - origin.y)
@@ -51,7 +51,7 @@ final class LineView: UIView, Drawable {
                 }
             }
         }
-
+        
         addGraphicSubLayer(aPath.cgPath)
         setNeedsDisplay()
     }
@@ -60,11 +60,14 @@ final class LineView: UIView, Drawable {
         guard let color = color,
               let layer = shapeLayer
         else { return }
-            
+        
         self.layer.sublayers?.removeAll()
         layer.strokeColor = CGColor(red: color.$r, green: color.$g, blue: color.$b, alpha: 1)
-        self.layer.addSublayer(layer)
-        setNeedsDisplay()
+        DispatchQueue.main.async { [weak self] in
+            self?.layer.addSublayer(layer)
+            self?.setNeedsDisplay()
+        }
+        
     }
     
     fileprivate func getOrigin(lines: [[CGPoint]]) -> Point {
@@ -90,6 +93,7 @@ final class LineView: UIView, Drawable {
         bezierLayer.strokeColor = CGColor(red: line.color.$r, green: line.color.$g, blue: line.color.$b, alpha: 1)
         bezierLayer.fillRule = .nonZero
         bezierLayer.fillColor = .none
+        bezierLayer.lineCap = .butt
         
         self.layer.addSublayer(bezierLayer)
         self.shapeLayer = bezierLayer

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
@@ -13,7 +13,7 @@ final class LineView: UIView, Drawable {
     var index: Int
     let lines: [[CGPoint]]
     var path: CGPath?
-    
+    let line: Line
     init(line: Line, index: Int) {
         self.index = index
         self.lines = line.lines.map({ line in
@@ -23,8 +23,10 @@ final class LineView: UIView, Drawable {
             }
             return tempLine
         })
+        self.line = line
         super.init(frame: CGRect(x: line.point.x, y: line.point.y, width: line.size.width, height: line.size.height))
-        super.backgroundColor = .systemBackground
+        self.layer.borderColor = tintColor.cgColor
+        self.sizeToFit()
         self.draw(self.frame)
     }
     
@@ -49,14 +51,21 @@ final class LineView: UIView, Drawable {
             }
         }
 
-        addGraphicSubLayer(aPath.cgPath, UIColor.red.cgColor)
+        addGraphicSubLayer(aPath.cgPath)
         self.path = aPath.cgPath
         
         setNeedsDisplay()
     }
     
     func updateAlphaOrColor(alpha: Alpha, color: Color?) {
-        assert(false)
+        guard let color = color else { return }
+
+        self.layer.sublayers?.forEach({ layer in
+            if case let bezierLayer as CAShapeLayer = layer {
+                bezierLayer.strokeColor = CGColor(red: color.$r, green: color.$g, blue: color.$b, alpha: 1)
+                return 
+            }
+        })
     }
     
     fileprivate func getOrigin(lines: [[CGPoint]]) -> Point {
@@ -75,15 +84,13 @@ final class LineView: UIView, Drawable {
         return Point(x: minX, y: minY)
     }
     
-    fileprivate func addGraphicSubLayer(_ path: CGPath, _ color: CGColor) {
+    fileprivate func addGraphicSubLayer(_ path: CGPath) {
         let bezierLayer = CAShapeLayer()
         bezierLayer.path = path
         bezierLayer.lineWidth = 5
-        bezierLayer.strokeColor = UIColor.red.cgColor
+        bezierLayer.strokeColor = CGColor(red: line.color.$r, green: line.color.$g, blue: line.color.$b, alpha: 1)
         bezierLayer.fillRule = .nonZero
         bezierLayer.fillColor = .none
-        bezierLayer.borderWidth = 3
-        bezierLayer.borderColor = UIColor.gray.cgColor
         
         self.layer.addSublayer(bezierLayer)
     }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
@@ -23,44 +23,43 @@ final class LineView: UIImageView, Drawable {
             return tempLine
         })
         super.init(frame: CGRect(x: line.point.x, y: line.point.y, width: line.size.width, height: line.size.height))
-        super.backgroundColor = .green
+        super.backgroundColor = .systemBackground
         super.layer.opacity = 0.5
-        dump(line.bound)
+        super.layer.borderColor = UIColor.brown.cgColor
+        super.layer.borderWidth = 3
+        self.draw(self.frame)
     }
     
     required init?(coder: NSCoder) {
         fatalError("This class shoud be made by init(), Not init?(coder:)")
     }
     
-//    override func draw(_ rect: CGRect) {
-//        super.draw(rect)
-//        guard let context = UIGraphicsGetCurrentContext() else { return }
-//        
-//        lines.forEach { line in
-//            for (i, p) in line.enumerated() {
-//                if i == 0 {
-//                    context.move(to: p)
-//                } else {
-//                    context.addLine(to: p)
-//                }
-//            }
-//        }
-//          
-////        for (i, p) in points.enumerated() {
-////            if i == 0 {
-////                context.move(to: p)
-////            } else {
-////                context.addLine(to: p)
-////            }
-////        }
-//          
-//        context.setStrokeColor(UIColor.red.cgColor)
-//        context.setLineWidth(5)
-//        context.setLineCap(.round)
-//        context.strokePath()
-//        
-//        setNeedsDisplay()
-//    }
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        guard let context = UIGraphicsGetCurrentContext() else { return }
+        
+        lines.forEach { line in
+            for (i, p) in line.enumerated() {
+                if i == 0 {
+                    context.move(to: p)
+                } else {
+                    context.addLine(to: p)
+                }
+            }
+        }
+        
+        context.setStrokeColor(UIColor.red.cgColor)
+        context.setLineWidth(5)
+        context.setLineCap(.round)
+        
+//        print(context.isPathEmpty)
+//        print(context.path)
+        context.strokePath()
+        context.drawPath(using: .stroke)
+//        UIGraphicsPopContext()
+        setNeedsDisplay()
+
+    }
     
     func updateAlphaOrColor(alpha: Alpha, color: Color?) {
         assert(false)

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/LineView.swift
@@ -12,8 +12,9 @@ final class LineView: UIView, Drawable {
     
     var index: Int
     let lines: [[CGPoint]]
-    var path: CGPath?
     let line: Line
+    var shapeLayer: CAShapeLayer?
+    
     init(line: Line, index: Int) {
         self.index = index
         self.lines = line.lines.map({ line in
@@ -52,20 +53,18 @@ final class LineView: UIView, Drawable {
         }
 
         addGraphicSubLayer(aPath.cgPath)
-        self.path = aPath.cgPath
-        
         setNeedsDisplay()
     }
     
     func updateAlphaOrColor(alpha: Alpha, color: Color?) {
-        guard let color = color else { return }
-
-        self.layer.sublayers?.forEach({ layer in
-            if case let bezierLayer as CAShapeLayer = layer {
-                bezierLayer.strokeColor = CGColor(red: color.$r, green: color.$g, blue: color.$b, alpha: 1)
-                return 
-            }
-        })
+        guard let color = color,
+              let layer = shapeLayer
+        else { return }
+            
+        self.layer.sublayers?.removeAll()
+        layer.strokeColor = CGColor(red: color.$r, green: color.$g, blue: color.$b, alpha: 1)
+        self.layer.addSublayer(layer)
+        setNeedsDisplay()
     }
     
     fileprivate func getOrigin(lines: [[CGPoint]]) -> Point {
@@ -93,5 +92,6 @@ final class LineView: UIView, Drawable {
         bezierLayer.fillColor = .none
         
         self.layer.addSublayer(bezierLayer)
+        self.shapeLayer = bezierLayer
     }
 }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/UIFactory.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/UIFactory.swift
@@ -17,6 +17,8 @@ final class UIFactory {
             return PhotoView(photo: photo, index: index)
         case let text as Text:
             return TextView(text: text, index: index)
+        case let line as Line:
+            return LineView(line: line, index: index)
         default:
             assert(false, "problem occured at \(#file)")
         }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/TableViewDataSource.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/TableViewDataSource.swift
@@ -29,7 +29,7 @@ extension CanvasViewController: UITableViewDataSource {
             case .text:
                 shapes = plane.shapes.filter { $0 is Text }
             case .drawing:
-                shapes = plane.shapes.filter { $0 is Shape }
+                shapes = plane.shapes.filter { $0 is Line }
             }
             counter = shapes.count
             for shape in shapes {
@@ -49,6 +49,8 @@ extension CanvasViewController: UITableViewDataSource {
             cell.setUp(with: .photo, at: indexPath.row, printNumber: getPrintNumber(target: .photo))
         case _ as Text:
             cell.setUp(with: .text, at: indexPath.row, printNumber: getPrintNumber(target: .text))
+        case _ as Line:
+            cell.setUp(with: .drawing, at: indexPath.row, printNumber: getPrintNumber(target: .drawing))
         default:
             break
         }

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/TableViewDataSource.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/TableViewDataSource.swift
@@ -28,6 +28,8 @@ extension CanvasViewController: UITableViewDataSource {
                 shapes = plane.shapes.filter { $0 is Photo }
             case .text:
                 shapes = plane.shapes.filter { $0 is Text }
+            case .drawing:
+                shapes = plane.shapes.filter { $0 is Shape }
             }
             counter = shapes.count
             for shape in shapes {

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/VCNotificationExtension.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/VCNotificationExtension.swift
@@ -30,7 +30,7 @@ extension CanvasViewController {
                 case .y:
                     currentView.layer.frame.origin.y = shape.point.y
                 case .width, .height:
-                    currentView.bounds = CGRect(
+                    currentView.frame = CGRect(
                         x: shape.point.x,
                         y: shape.point.y,
                         width: shape.size.width,

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/VCShapeExtension.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/VCShapeExtension.swift
@@ -12,8 +12,9 @@ extension CanvasViewController {
     
     // MARK: - 상태창에 선택된 스퀘어 뷰를 알리기
     func informSelectedViewToStatus(color: Color, alpha: Alpha, type blueprint: ShapeBlueprint) {
-        let buttonTitleString = blueprint == .rectangle ? color.hexaColor : "비어있음"
-        colorButton.isEnabled = blueprint == .rectangle ? true : false
+        let hasColor: Bool = blueprint == .rectangle || blueprint == .drawing
+        let buttonTitleString = hasColor ? color.hexaColor : "비어있음"
+        colorButton.isEnabled = hasColor ? true : false
         colorButton.setTitle(buttonTitleString, for: .normal)
         adjustSliderAndStepper(by: alpha)
         statusView.isHidden = false

--- a/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/VCShapeExtension.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Canvas/View/VCDelegates + extensions/VCShapeExtension.swift
@@ -18,6 +18,13 @@ extension CanvasViewController {
         colorButton.setTitle(buttonTitleString, for: .normal)
         adjustSliderAndStepper(by: alpha)
         statusView.isHidden = false
+        if blueprint == .drawing {
+            self.stepper.isEnabled = false
+            self.slider.isEnabled = false
+        } else {
+            self.stepper.isEnabled = true
+            self.slider.isEnabled = true
+        }
     }
     
     func updatePropertiesLabels(with view: UIView) {

--- a/DrawingAppGucci/DrawingApp/Source/Support/AppDelegate.swift
+++ b/DrawingAppGucci/DrawingApp/Source/Support/AppDelegate.swift
@@ -20,9 +20,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
     
-//    func applicationWillTerminate(_ application: UIApplication) {
-
-//    }
-    
 }
 


### PR DESCRIPTION
# 작업 내용
- [x] 터치 이동을 좌표로 변환하여 그림
- [x] 위치와 크기 설정
- [x] 선 색상 랜덤
- [x] 투명도 예외
- [x] 오브젝트 목록 반영

# 구현 데모 
![image](https://user-images.githubusercontent.com/50472122/187014579-caf1d639-7706-4ec0-ae68-e0a746a25dec.png)

# 고민과 해결

- **UIGraphicsCurrentContext() 를 잘 알 수 없었다. **
  - 역시나 너무 어렵게 생각하는 경향이 있다. 뷰를 보여줄 곳에서 그려야지, 엄한곳에서 그리고 보여주기만 하려니 문제가 되었다.
  - context 를 다루는게 UIGraphicsCurrentContext(), UIGraphicsPushContext(), UIGraphicsPopContext() 가 있는데, 정확한 사용법을 알기 어려워서, bezierPath 를 사용했다. 
  - 게다가 그림을 그리는게, context 를 사용하면 stroke 한 번이면 끝나는데, bezier Path 를 쓰게 되면 CAShapeLayer 를 하위 레이어에 추가하는 것을 몰라서 엄청 애먹었다.
- **실제 path 가 그려지는 좌표(배경뷰 좌표계)가 view에서의 좌표와 차이가 나서 겪은 어려운 점**
  - 너무 어렵게 생각해서 어려워졌다. 
